### PR TITLE
Updates for v1.2.0

### DIFF
--- a/PublishHtmlReport/index.js
+++ b/PublishHtmlReport/index.js
@@ -1,60 +1,74 @@
-const tl = require('azure-pipelines-task-lib');
-const { resolve, basename, join } = require('path');
-const dashify = require('dashify')
-const globby = require('globby')
-const { readFileSync, writeFileSync } = require('fs')
-const { load } = require('cheerio')
+const tl = require('azure-pipelines-task-lib/task');
+const globby = require('globby');
+const { readFileSync, writeFileSync, statSync } = require('fs');
+const { resolve, basename, dirname } = require('path');
+const cheerio = require('cheerio');
+const dashify = require('dashify');
 
-function run () {
-    let reportDir = tl.getPathInput('reportDir', true, true);
-    let files = globby.sync([reportDir.replace(/\\/g, '/')], {expandDirectories : {files: ['*'], extensions: ['html']}})
-
-    const fileProperties = []
-
-    files.forEach(file => {
-      tl.debug(`Reading report ${file}`)
-      const fileContent = readFileSync(file).toString()
-      const document = load(fileContent)
-      writeFileSync(file, document.html())
-
-      const attachmentProperties = {
-        name: generateName(basename(file)),
-        type: 'report-html'
-      }
-
-      fileProperties.push(attachmentProperties)
-      tl.command('task.addattachment', attachmentProperties, file)
-
-    })
-
-    const jobName = dashify(tl.getVariable('Agent.JobName'))
-    const stageName = dashify(tl.getVariable('System.StageDisplayName'))
-    const stageAttempt = tl.getVariable('System.StageAttempt')
-    const tabName = tl.getInput('tabName', false ) || 'Html-Report'
-    const summaryPath = resolve(reportDir)
-    writeFileSync(summaryPath, JSON.stringify(fileProperties))
-    console.log(summaryPath)
-    tl.addAttachment('report-html', `${tabName}.${jobName}.${stageName}.${stageAttempt}`, summaryPath)
+function addTaskAttachment(attachmentProps) {
+    tl.addAttachment(attachmentProps.type, attachmentProps.name, attachmentProps.path);
 }
 
-function generateName (fileName) {
-    const jobName = dashify(tl.getVariable('Agent.JobName'))
-    const stageName = dashify(tl.getVariable('System.StageDisplayName'))
-    const stageAttempt = tl.getVariable('System.StageAttempt')
-    const tabName = tl.getInput('tabName', false ) || 'Html-Report'
+function run() {
+    try {
+        const reportInputPath = tl.getPathInput('reportDir', true, false);
+        let files = [];
+        let summaryPath;
 
-    return `${tabName}.${jobName}.${stageName}.${stageAttempt}.${fileName}`
+        // Check if reportInputPath is a directory or a file
+        if (statSync(reportInputPath).isDirectory()) {
+            files = globby.sync([`${reportInputPath}/**/*.html`]); // Find all HTML files within the directory
+            summaryPath = resolve(reportInputPath, 'summary.json'); // Place summary in the directory
+        } else {
+            files = [reportInputPath]; // Single file case
+            summaryPath = resolve(dirname(reportInputPath), 'summary.json'); // Place summary in the directory containing the file
+        }
+
+        const fileProperties = [];
+        const summaryProperties = {
+            name: generateSummaryName(),
+            type: 'report-html-summary',
+            path: summaryPath
+        };
+
+        files.forEach(file => {
+            tl.debug(`Reading report ${file}`);
+            const fileContent = readFileSync(file, 'utf8');
+            const document = cheerio.load(fileContent);
+            writeFileSync(file, document.html());
+
+            const attachmentProperties = {
+                name: generateAttachmentName(basename(file)),
+                type: 'report-html',
+                path: file
+            };
+
+            fileProperties.push(attachmentProperties);
+            addTaskAttachment(attachmentProperties);
+        });
+
+        // Save the summary file
+        writeFileSync(summaryPath, JSON.stringify(fileProperties));
+        addTaskAttachment(summaryProperties);
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, error.message);
+    }
 }
 
-try {
-    let reportDir = tl.getPathInput('reportDir', true, true);
-    const jobName = dashify(tl.getVariable('Agent.JobName'))
-    const stageName = dashify(tl.getVariable('System.StageDisplayName'))
-    const stageAttempt = tl.getVariable('System.StageAttempt')
-    const tabName = tl.getInput('tabName', false ) || 'Html-Report'
-    let path = resolve(reportDir)
-    console.log(path)
-    tl.addAttachment('report-html', `${tabName}.${jobName}.${stageName}.${stageAttempt}`, path)
-} catch (error) {
-    tl.setResult(tl.TaskResult.SucceededWithIssues, error.message);
+function generateAttachmentName(fileName) {
+    const jobName = dashify(tl.getVariable('Agent.JobName'));
+    const stageName = dashify(tl.getVariable('System.StageDisplayName'));
+    const stageAttempt = tl.getVariable('System.StageAttempt');
+    const tabName = tl.getInput('tabName', false) || 'Html-Report';
+    return `${tabName}.${jobName}.${stageName}.${stageAttempt}.${fileName}`;
 }
+
+function generateSummaryName() {
+    const jobName = dashify(tl.getVariable('Agent.JobName'));
+    const stageName = dashify(tl.getVariable('System.StageDisplayName'));
+    const stageAttempt = tl.getVariable('System.StageAttempt');
+    const tabName = tl.getInput('tabName', false) || 'Html-Report';
+    return `${tabName}.${jobName}.${stageName}.${stageAttempt}`;
+}
+
+run();

--- a/PublishHtmlReport/package-lock.json
+++ b/PublishHtmlReport/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-html-report",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-html-report",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "azure-pipelines-task-lib": "^4.1.0",

--- a/PublishHtmlReport/package.json
+++ b/PublishHtmlReport/package.json
@@ -1,7 +1,8 @@
 {
   "name": "publish-html-report",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
+  "author": "Jakub Rumpca, BlakYaks",
   "main": "index.js",
   "private": true,
   "dependencies": {
@@ -17,6 +18,5 @@
     "azure-devops-ui": "^2.246.0"
   },
   "scripts": {},
-  "author": "",
   "license": "ISC"
 }

--- a/PublishHtmlReport/task.json
+++ b/PublishHtmlReport/task.json
@@ -12,8 +12,8 @@
   "demands": [],
   "version": {
     "Major": "1",
-    "Minor": "1",
-    "Patch": "1"
+    "Minor": "2",
+    "Patch": "0"
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Publish Html Report",
@@ -29,10 +29,10 @@
     {
       "name": "reportDir",
       "type": "filePath",
-      "label": "HTML file Directory",
+      "label": "HTML file or directory path",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "HTML file directory where PublishHtmlReport is run"
+      "helpMarkDown": "The HTML file or directory path for the file(s) to be published"
     }
   ],
   "execution": {

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Html Reports (BlakYaks.azure-pipeline-html-reports)
 
-An Azure DevOps extension that provides a task for publishing report in a HTML format and embeds it into a Build and Release pages.
+An Azure DevOps extension that provides a task for publishing HTML formatted reports onto build and release pages.
 
 ## Using the extension
 
 In order to see a report tab you must use the  `Publish HTML Report` task. This is a supporting task which adds HTML output from the build pipeline(s) for viewing.
 
-The task takes one mandatory parameter `reportDir` which should reference the HTML filename to be published. The optional `tabName` parameter may also be supplied to configure the name of the tab displayed under `Reports` in the Azure DevOps UI.
+The task takes one mandatory parameter `reportDir` which should reference the HTML filename or directory to be published. The optional `tabName` parameter may also be supplied to configure the name of the tab displayed under `Reports` in the Azure DevOps UI.
 
 ### Example YAML setup
 
@@ -21,27 +21,26 @@ steps:
 
 ## Changelog
 
-### v1.1.1 - BlakYaks Release
+### v1.2.0
+
+- Addresses this [issue](https://github.com/blakyaks/azure-pipeline-html-reports/issues/2) which was carried over from the original source project. The `reportDir` property now supports both directory and file paths; if a directory is specified, all `*.html` files in that directory will be displayed. An example is shown below:
+
+```yaml
+- task: PublishHtmlReport@1
+  displayName: Publish Directory Reports
+  condition: succeededOrFailed()
+  inputs:
+    reportDir: 'cypress/reports'
+    tabName: 'E2E ${{ parameters.region }}-${{ parameters.slotName }}'
+```
+
+### v1.1.1
 
 This version patches the [AwardedSolutions](https://github.com/FreakinWard/azure-pipeline-html-report) release and is now maintained for future support purposes. The BlakYaks release supports Node 16 and Node 20 runners, removing the deprecation notice displayed during pipeline runs.
 
 Task names and inputs were maintained to simplify update from previous releases.
 
-### v1.0.8
-
-This extension patches the original [HTML Viewer by Jakub Rumpca](https://marketplace.visualstudio.com/items?itemName=JakubRumpca.azure-pipelines-html-report) and resolves [#8 TabName incorrectly renders when using multi-stage pipelines](https://github.com/JakubRumpca/azure-pipeline-html-report/issues/8)
-
-Before fix:
-
-![githubIssue8.png](https://github.com/FreakinWard/azure-pipeline-html-report/blob/main/docs/githubIssue8.png?raw=true)
-
-After fix:
-
-![githubIssue8-fixed.png](https://github.com/FreakinWard/azure-pipeline-html-report/blob/main/docs/githubIssue8-fixed.png?raw=true)
-
 ```yaml
-
-# tabName has a known bug w/multi-stages: https://github.com/JakubRumpca/azure-pipeline-html-report/issues/8
 - task: PublishHtmlReport@1
   displayName: Publish E2E Test Report
   condition: succeededOrFailed()
@@ -49,4 +48,3 @@ After fix:
     reportDir: 'cypress/reports/index.html'
     tabName: 'E2E ${{ parameters.region }}-${{ parameters.slotName }}'
 ```
-

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "azure-pipelines-html-reports",
     "publisher": "BlakYaks",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "author": "Jakub Rumpca & BlakYaks",
     "name": "Html Reports",
     "description": "Embed HTML reports in Azure Pipelines",

--- a/dev_manifest.json
+++ b/dev_manifest.json
@@ -1,4 +1,7 @@
 {
     "manifestVersion": 1,
-    "public": false
+    "id": "azure-pipelines-html-reports-dev",
+    "public": false,
+    "version": "1.2.0",
+    "name": "Html Reports (Dev)"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-html-report",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-html-report",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@material-ui/core": "^4.10.1",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "azure-pipelines-html-report",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
-  "author": "Jakub Rumpca",
+  "author": "Jakub Rumpca, BlakYaks",
   "dependencies": {
     "@material-ui/core": "^4.10.1",
     "@material-ui/icons": "^4.9.1",

--- a/src/tabContent.html
+++ b/src/tabContent.html
@@ -66,7 +66,7 @@
 </head>
 
 <body>
-  <div id="html-report-extention-container"></div>
+  <div id="html-report-extension-container"></div>
   <script type="text/javascript" src="tabContent.js" charset="utf-8"></script>
 </body>
 </html>

--- a/src/tabContent.scss
+++ b/src/tabContent.scss
@@ -3,6 +3,5 @@
 .bolt-tabbar-tabs {
     font-size: $fontSizeM;
     margin-bottom: 10px;
-    // font-family: Arial, sans-serif;
     font-family: "Segoe UI VSS (Regular)","Segoe UI","-apple-system",BlinkMacSystemFont,Roboto,"Helvetica Neue",Helvetica,Ubuntu,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   }

--- a/src/tabContent.tsx
+++ b/src/tabContent.tsx
@@ -11,7 +11,6 @@ import { ObservableValue, ObservableObject } from "azure-devops-ui/Core/Observab
 import { Observer } from "azure-devops-ui/Observer"
 import { Tab, TabBar, TabSize } from "azure-devops-ui/Tabs"
 
-
 const ATTACHMENT_TYPE = "report-html";
 
 SDK.init()
@@ -30,7 +29,7 @@ SDK.ready().then(() => {
 })
 
 function displayReports(attachmentClient: AttachmentClient) {
-  ReactDOM.render(<TaskAttachmentPanel attachmentClient={attachmentClient} />, document.getElementById("html-report-extention-container"))
+  ReactDOM.render(<TaskAttachmentPanel attachmentClient={attachmentClient} />, document.getElementById("html-report-extension-container"))
 }
 
 abstract class AttachmentClient {


### PR DESCRIPTION
Fixes #2 

Updates the task so that it can interpret the `reportDir` input as either a directory or a filename. Fixes an issue from the original forked codebase.