### PR TITLE
v1.2.1 - Adds feature for file-based tab names

### DIFF
--- a/PublishHtmlReport/package-lock.json
+++ b/PublishHtmlReport/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-html-report",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-html-report",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "azure-pipelines-task-lib": "^4.1.0",

--- a/PublishHtmlReport/package.json
+++ b/PublishHtmlReport/package.json
@@ -1,7 +1,7 @@
 {
   "name": "publish-html-report",
-  "version": "1.2.0",
-  "description": "",
+  "version": "1.2.1",
+  "description": "Pipelines task that publishes HTML report files",
   "author": "Jakub Rumpca, BlakYaks",
   "main": "index.js",
   "private": true,

--- a/PublishHtmlReport/task.json
+++ b/PublishHtmlReport/task.json
@@ -4,7 +4,7 @@
   "friendlyName": "Publish Html Report",
   "description": "Publish Html Report",
   "author": "BlakYaks",
-  "helpMarkDown": "Embeds HTML reports in Azure Pipelines",
+  "helpMarkDown": "Pipelines task that publishes HTML report files",
   "category": "Utility",
   "visibility": [
     "Build"
@@ -13,7 +13,7 @@
   "version": {
     "Major": "1",
     "Minor": "2",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Publish Html Report",
@@ -33,6 +33,14 @@
       "defaultValue": "",
       "required": true,
       "helpMarkDown": "The HTML file or directory path for the file(s) to be published"
+    },
+    {
+      "name": "useFilenameTabs",
+      "type": "boolean",
+      "label": "Use filenames as tab names",
+      "defaultValue": "true",
+      "required": false,
+      "helpMarkDown": "When using reports from a directory, use the filename as the tab header for each file."
     }
   ],
   "execution": {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Html Reports (BlakYaks.azure-pipeline-html-reports)
+# Html Reports (blakyaks.azure-pipeline-html-reports)
 
 An Azure DevOps extension that provides a task for publishing HTML formatted reports onto build and release pages.
 
@@ -6,9 +6,11 @@ An Azure DevOps extension that provides a task for publishing HTML formatted rep
 
 In order to see a report tab you must use the  `Publish HTML Report` task. This is a supporting task which adds HTML output from the build pipeline(s) for viewing.
 
-The task takes one mandatory parameter `reportDir` which should reference the HTML filename or directory to be published. The optional `tabName` parameter may also be supplied to configure the name of the tab displayed under `Reports` in the Azure DevOps UI.
+- The task takes one mandatory parameter `reportDir` which should reference the HTML filename or directory to be published. The optional `tabName` parameter may also be supplied to configure the name of the tab displayed under `Reports` in the Azure DevOps UI.
 
-### Example YAML setup
+- Report tab names will use the filename rather than the `tabName` when a directory path has been provided for the `reportDir` parameter. This is the default behaviour and must be overridden by setting `useFilenameTabs` parameter is set to `false`.
+
+### Example YAML use
 
 ```YAML
 steps:
@@ -16,14 +18,20 @@ steps:
     displayName: 'Publish HTML Report'
     inputs:
       reportDir: '$(ResultsPath)/reportName.html'
+      useFilenameTabs: true
       tabName: MyReport
 ```
 
 ## Changelog
 
+### v1.2.1
+
+- Added support for setting tab names automatically based on filename when scanning directories for reports as per this [feature request](https://github.com/blakyaks/azure-pipeline-html-reports/issues/4)
+- Removed the stage attempt badge for initial job runs
+
 ### v1.2.0
 
-- Addresses this [issue](https://github.com/blakyaks/azure-pipeline-html-reports/issues/2) which was carried over from the original source project. The `reportDir` property now supports both directory and file paths; if a directory is specified, all `*.html` files in that directory will be displayed. An example is shown below:
+- Addresses this [issue](https://github.com/blakyaks/azure-pipeline-html-reports/issues/2) which was carried over from the original source project. The `reportDir` property now supports both directory and file paths; if a directory is specified, all `*.html` and `*.htm` files in that directory will be displayed. An example is shown below:
 
 ```yaml
 - task: PublishHtmlReport@1

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "azure-pipelines-html-reports",
     "publisher": "BlakYaks",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "author": "Jakub Rumpca & BlakYaks",
     "name": "Html Reports",
     "description": "Embed HTML reports in Azure Pipelines",

--- a/dev_manifest.json
+++ b/dev_manifest.json
@@ -2,6 +2,6 @@
     "manifestVersion": 1,
     "id": "azure-pipelines-html-reports-dev",
     "public": false,
-    "version": "1.2.0",
+    "version": "1.2.x",
     "name": "Html Reports (Dev)"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-html-report",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-html-report",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "author": "Jakub Rumpca, BlakYaks",
   "dependencies": {

--- a/src/tabContent.tsx
+++ b/src/tabContent.tsx
@@ -118,14 +118,17 @@ export default class TaskAttachmentPanel extends React.Component<TaskAttachmentP
     } else {
       const tabs = []
       for (const attachment of attachments) {
-        const metadata = attachment.name.split('.')
+        const metadata = attachment.name.split('~')
 
         // Determine the tab name and optionally add a badge count
         let name = metadata[0];
         let badgeCount = undefined; // Default badgeCount is undefined which means no badge is shown
 
         if (metadata[2] !== '__default') {
-            badgeCount = parseInt(metadata[3]); // Convert metadata[3] to an integer for badgeCount
+            // Only add badgeCount for secondary attempts
+            if (parseInt(metadata[3]) > 1) {
+              badgeCount = parseInt(metadata[3]);
+            }
         }
 
         tabs.push(<Tab


### PR DESCRIPTION
Fixes #4 

- Adds update to use filenames as tab headers when scanning directories for reports
- Removed attempt badge for non-secondary runs